### PR TITLE
Fix MIN_GLOBAL_BUFFER_SIZE in JfrOptionSet to match jdk 11

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrOptionSet.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrOptionSet.java
@@ -44,7 +44,7 @@ public class JfrOptionSet {
 
     private static final long MAX_ADJUSTED_GLOBAL_BUFFER_SIZE = 1 * 1024 * 1024;
     private static final long MIN_ADJUSTED_GLOBAL_BUFFER_SIZE_CUTOFF = 512 * 1024;
-    private static final long MIN_GLOBAL_BUFFER_SIZE = 64 * 1024 * 1024;
+    private static final long MIN_GLOBAL_BUFFER_SIZE = 64 * 1024;
     private static final long MIN_GLOBAL_BUFFER_COUNT = 2;
     private static final long MIN_THREAD_BUFFER_SIZE = 4 * 1024;
     private static final long MIN_MEMORY_SIZE = 1 * 1024 * 1024;


### PR DESCRIPTION
MIN_GLOBAL_BUFFER_SIZE is 64 * K in src/hotspot/share/jfr/recorder/service/jfrMemorySizer.cpp

so default recordings fail the assertion in checkPostCondition for this setting.