### PR TITLE
Adjust ThreadListenerSupport before/after calls

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/management/SubstrateThreadMXBean.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/management/SubstrateThreadMXBean.java
@@ -50,9 +50,9 @@ final class SubstrateThreadMXBean implements com.sun.management.ThreadMXBean {
      * Initial values account for the main thread (a non-daemon thread) that is running without an
      * explicit notification at startup.
      */
-    private final AtomicLong totalStartedThreadCount = new AtomicLong(1);
-    private final AtomicInteger peakThreadCount = new AtomicInteger(1);
-    private final AtomicInteger threadCount = new AtomicInteger(1);
+    private final AtomicLong totalStartedThreadCount = new AtomicLong(0);
+    private final AtomicInteger peakThreadCount = new AtomicInteger(0);
+    private final AtomicInteger threadCount = new AtomicInteger(0);
     private final AtomicInteger daemonThreadCount = new AtomicInteger(0);
 
     @Platforms(Platform.HOSTED_ONLY.class)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/management/SubstrateThreadMXBean.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/management/SubstrateThreadMXBean.java
@@ -46,10 +46,6 @@ final class SubstrateThreadMXBean implements com.sun.management.ThreadMXBean {
 
     private static final String MSG = "ThreadMXBean methods";
 
-    /*
-     * Initial values account for the main thread (a non-daemon thread) that is running without an
-     * explicit notification at startup.
-     */
     private final AtomicLong totalStartedThreadCount = new AtomicLong(0);
     private final AtomicInteger peakThreadCount = new AtomicInteger(0);
     private final AtomicInteger threadCount = new AtomicInteger(0);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaThreads.java
@@ -202,6 +202,7 @@ public abstract class JavaThreads {
 
         Target_java_lang_Thread javaThread = SubstrateUtil.cast(currentThread.get(thread), Target_java_lang_Thread.class);
         javaThread.exit();
+        ThreadListenerSupport.get().afterThreadExit(CurrentIsolate.getCurrentThread(), currentThread.get(thread));
     }
 
     /**
@@ -317,6 +318,7 @@ public abstract class JavaThreads {
     public void initializeIsolate() {
         /* The thread that creates the isolate is considered the "main" thread. */
         currentThread.set(mainThread);
+        ThreadListenerSupport.get().beforeThreadStart(CurrentIsolate.getCurrentThread(), mainThread);
     }
 
     /**
@@ -506,7 +508,6 @@ public abstract class JavaThreads {
 
         try {
             ThreadListenerSupport.get().beforeThreadStart(CurrentIsolate.getCurrentThread(), thread);
-
             if (VMThreads.isTearingDown()) {
                 /*
                  * As a newly started thread, we might not have been interrupted like the Java
@@ -520,7 +521,6 @@ public abstract class JavaThreads {
             dispatchUncaughtException(thread, ex);
         } finally {
             exit(thread);
-            ThreadListenerSupport.get().afterThreadExit(CurrentIsolate.getCurrentThread(), thread);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaThreads.java
@@ -300,6 +300,7 @@ public abstract class JavaThreads {
     public static void assignJavaThread(Thread thread, boolean manuallyStarted) {
         VMError.guarantee(currentThread.get() == null, "overwriting existing java.lang.Thread");
         currentThread.set(thread);
+        ThreadListenerSupport.get().beforeThreadStart(CurrentIsolate.getCurrentThread(), thread);
 
         /* If the thread was manually started, finish initializing it. */
         if (manuallyStarted) {
@@ -507,7 +508,6 @@ public abstract class JavaThreads {
         singleton().beforeThreadRun(thread);
 
         try {
-            ThreadListenerSupport.get().beforeThreadStart(CurrentIsolate.getCurrentThread(), thread);
             if (VMThreads.isTearingDown()) {
                 /*
                  * As a newly started thread, we might not have been interrupted like the Java


### PR DESCRIPTION
Moves `afterThreadExit` to be in `cleanupBeforeDetach`. Adds `beforeThreadRun` when setting main thread and adjusts the other instance to also catch threads attaching e.g. via JNI.