### PR TITLE
Remove extra reinitialize call

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrThreadLocal.java
@@ -235,7 +235,6 @@ public class JfrThreadLocal implements ThreadListener {
     private static void writeDataLoss(JfrBuffer buffer, UnsignedWord unflushedSize) {
         assert buffer.isNonNull();
         assert unflushedSize.aboveThan(0);
-        JfrBufferAccess.reinitialize(buffer);
         UnsignedWord totalDataLoss = increaseDataLost(unflushedSize);
         if (SubstrateJVM.isRecording() && SubstrateJVM.get().isEnabled(JfrEvents.DataLossEvent)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);


### PR DESCRIPTION
Removes an extra reinitialize call in writeDataLoss as the caller already reinitializes the buffer.