### PR TITLE
Notify java event writers during epoch change

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrThreadLocal.java
@@ -205,6 +205,13 @@ public class JfrThreadLocal implements ThreadListener {
         return result;
     }
 
+    @Uninterruptible(reason = "Called by uninterruptible code.", callerMustBe = true)
+    public static void notifyEventWriter(IsolateThread thread) {
+        if (javaEventWriter.get(thread) != null) {
+            javaEventWriter.get(thread).notified = true;
+        }
+    }
+
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public static JfrBuffer flush(JfrBuffer threadLocalBuffer, UnsignedWord uncommitted, int requested) {
         assert threadLocalBuffer.isNonNull();

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/Target_jdk_jfr_internal_EventWriter.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/Target_jdk_jfr_internal_EventWriter.java
@@ -31,6 +31,10 @@ import com.oracle.svm.core.annotate.TargetClass;
 public final class Target_jdk_jfr_internal_EventWriter {
     @Alias
     @SuppressWarnings("unused")
+    boolean notified;
+
+    @Alias
+    @SuppressWarnings("unused")
     Target_jdk_jfr_internal_EventWriter(long startPos, long maxPos, long startPosAddress, long threadID, boolean valid) {
     }
 }


### PR DESCRIPTION
This makes sure the event writers reset after safepoint ends so that the events that are in-progress will retag any constant pool entries for the new epoch.