### PR TITLE
Implement more parts of CloseFileOperation

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrBuffer.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrBuffer.java
@@ -57,6 +57,12 @@ public interface JfrBuffer extends PointerBase {
     }
 
     @RawField
+    Pointer getTop();
+
+    @RawField
+    void setTop(Pointer value);
+
+    @RawField
     int getAcquired();
 
     @RawField

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrBufferAccess.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrBufferAccess.java
@@ -72,6 +72,7 @@ public final class JfrBufferAccess {
     public static void reinitialize(JfrBuffer buffer) {
         Pointer pos = getDataStart(buffer);
         buffer.setPos(pos);
+        buffer.setTop(pos);
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
@@ -113,12 +114,17 @@ public final class JfrBufferAccess {
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static UnsignedWord getUnflushedSize(JfrBuffer buffer) {
-        return buffer.getPos().subtract(getDataStart(buffer));
+        return buffer.getPos().subtract(buffer.getTop());
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static void increasePos(JfrBuffer buffer, UnsignedWord delta) {
         buffer.setPos(buffer.getPos().add(delta));
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public static void increaseTop(JfrBuffer buffer, UnsignedWord delta) {
+        buffer.setTop(buffer.getTop().add(delta));
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrChunkWriter.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrChunkWriter.java
@@ -36,6 +36,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import com.oracle.svm.core.thread.VMOperationControl;
 import org.graalvm.compiler.core.common.NumUtil;
+import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
@@ -43,6 +44,7 @@ import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.annotate.Uninterruptible;
 import com.oracle.svm.core.jdk.Target_java_nio_DirectByteBuffer;
 import com.oracle.svm.core.thread.JavaVMOperation;
+import com.oracle.svm.core.thread.VMThreads;
 
 import jdk.jfr.internal.Logger;
 
@@ -408,6 +410,10 @@ public final class JfrChunkWriter implements JfrUnlockedChunkWriter {
             // - Flush all thread-local buffers (native & Java) to global JFR memory.
             // - Set all Java EventWriter.notified values
             // - Change the epoch.
+
+            for (IsolateThread thread = VMThreads.firstThread(); thread.isNonNull(); thread = VMThreads.nextThread(thread)) {
+                JfrThreadLocal.notifyEventWriter(thread);
+            }
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrChunkWriter.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrChunkWriter.java
@@ -441,7 +441,11 @@ public final class JfrChunkWriter implements JfrUnlockedChunkWriter {
                 JfrBufferAccess.release(buffer);
 
                 if (shouldNotify) {
-                    Target_jdk_jfr_internal_JVM.FILE_DELTA_CHANGE.notify();
+                    //Checkstyle: stop
+                    synchronized (Target_jdk_jfr_internal_JVM.FILE_DELTA_CHANGE) {
+                        Target_jdk_jfr_internal_JVM.FILE_DELTA_CHANGE.notifyAll();
+                    }
+                    //Checkstyle: resume
                 }
             }
         }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrChunkWriter.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrChunkWriter.java
@@ -35,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.locks.ReentrantLock;
 
 import com.oracle.svm.core.thread.VMOperationControl;
+import com.oracle.svm.jfr.traceid.JfrTraceIdEpoch;
 import org.graalvm.compiler.core.common.NumUtil;
 import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.Platform;
@@ -421,6 +422,7 @@ public final class JfrChunkWriter implements JfrUnlockedChunkWriter {
             for (IsolateThread thread = VMThreads.firstThread(); thread.isNonNull(); thread = VMThreads.nextThread(thread)) {
                 JfrThreadLocal.flushAndNotifyAtSafepoint(thread);
             }
+            JfrTraceIdEpoch.getInstance().changeEpoch();
         }
     }
 

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrChunkWriter.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrChunkWriter.java
@@ -426,12 +426,6 @@ public final class JfrChunkWriter implements JfrUnlockedChunkWriter {
         }
     }
 
-    @Uninterruptible(reason = "Epoch must not change while in this method.")
-    private static boolean shouldDiscard() {
-        // TODO: implement
-        return false;
-    }
-
     public void persistBuffers(JfrGlobalMemory globalMemory) {
         JfrBuffers buffers = globalMemory.getBuffers();
         for (int i = 0; i < globalMemory.getBufferCount(); i++) {

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrGlobalMemory.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrGlobalMemory.java
@@ -92,11 +92,11 @@ public class JfrGlobalMemory {
         // Copy all committed but not yet flushed memory to the promotion buffer.
         JfrRecorderThread recorderThread = SubstrateJVM.getRecorderThread();
         assert JfrBufferAccess.getAvailableSize(promotionBuffer).aboveOrEqual(unflushedSize);
-        UnmanagedMemoryUtil.copy(JfrBufferAccess.getDataStart(threadLocalBuffer), promotionBuffer.getPos(), unflushedSize);
+        UnmanagedMemoryUtil.copy(threadLocalBuffer.getTop(), promotionBuffer.getPos(), unflushedSize);
         JfrBufferAccess.increasePos(promotionBuffer, unflushedSize);
         boolean shouldSignal = recorderThread.shouldSignal(promotionBuffer);
         releasePromotionBuffer(promotionBuffer);
-
+        JfrBufferAccess.increaseTop(threadLocalBuffer, unflushedSize);
         // Notify the thread that writes the global memory to disk.
         if (shouldSignal) {
             recorderThread.signal();

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrRecorderThread.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrRecorderThread.java
@@ -24,8 +24,6 @@
  */
 package com.oracle.svm.jfr;
 
-import org.graalvm.word.UnsignedWord;
-
 import com.oracle.svm.core.annotate.Uninterruptible;
 import com.oracle.svm.core.locks.VMCondition;
 import com.oracle.svm.core.locks.VMMutex;
@@ -37,8 +35,6 @@ import com.oracle.svm.core.util.VMError;
  * a file.
  */
 public class JfrRecorderThread extends Thread {
-    private static final int BUFFER_FULL_ENOUGH_PERCENTAGE = 50;
-
     private final JfrGlobalMemory globalMemory;
     private final JfrUnlockedChunkWriter unlockedChunkWriter;
     private final VMMutex mutex;
@@ -69,7 +65,7 @@ public class JfrRecorderThread extends Thread {
                 JfrChunkWriter chunkWriter = unlockedChunkWriter.lock();
                 try {
                     if (chunkWriter.hasOpenFile()) {
-                        persistBuffers(chunkWriter);
+                        chunkWriter.persistBuffers(globalMemory);
                     }
                 } finally {
                     chunkWriter.unlock();
@@ -92,26 +88,6 @@ public class JfrRecorderThread extends Thread {
         }
     }
 
-    private void persistBuffers(JfrChunkWriter chunkWriter) {
-        JfrBuffers buffers = globalMemory.getBuffers();
-        for (int i = 0; i < globalMemory.getBufferCount(); i++) {
-            JfrBuffer buffer = buffers.addressOf(i).read();
-            if (isFullEnough(buffer) && JfrBufferAccess.acquire(buffer)) {
-                boolean shouldNotify = chunkWriter.write(buffer);
-                JfrBufferAccess.reinitialize(buffer);
-                JfrBufferAccess.release(buffer);
-
-                if (shouldNotify) {
-                    //Checkstyle: stop
-                    synchronized (Target_jdk_jfr_internal_JVM.FILE_DELTA_CHANGE) {
-                        Target_jdk_jfr_internal_JVM.FILE_DELTA_CHANGE.notifyAll();
-                    }
-                    //Checkstyle: resume
-                }
-            }
-        }
-    }
-
     /**
      * We need to be a bit careful with this method as the recorder thread can't do anything if the
      * chunk writer doesn't have an output file.
@@ -124,12 +100,8 @@ public class JfrRecorderThread extends Thread {
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public boolean shouldSignal(JfrBuffer buffer) {
-        return isFullEnough(buffer) && unlockedChunkWriter.hasOpenFile();
+        return JfrChunkWriter.isFullEnough(buffer) && unlockedChunkWriter.hasOpenFile();
     }
 
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    private static boolean isFullEnough(JfrBuffer buffer) {
-        UnsignedWord bufferTargetSize = buffer.getSize().multiply(100).unsignedDivide(BUFFER_FULL_ENOUGH_PERCENTAGE);
-        return JfrBufferAccess.getAvailableSize(buffer).belowOrEqual(bufferTargetSize);
-    }
+
 }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrThreadLocal.java
@@ -205,6 +205,13 @@ public class JfrThreadLocal implements ThreadListener {
         return result;
     }
 
+    @Uninterruptible(reason = "Called by uninterruptible code.", callerMustBe = true)
+    public static void notifyEventWriter(IsolateThread thread) {
+        if (javaEventWriter.get(thread) != null) {
+            javaEventWriter.get(thread).notified = true;
+        }
+    }
+
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public static JfrBuffer flush(JfrBuffer threadLocalBuffer, UnsignedWord uncommitted, int requested) {
         assert threadLocalBuffer.isNonNull();

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrThreadLocal.java
@@ -238,6 +238,31 @@ public class JfrThreadLocal implements ThreadListener {
         return WordFactory.nullPointer();
     }
 
+
+    @Uninterruptible(reason = "Accesses a JFR buffer.")
+    public static void flushAndNotifyAtSafepoint(IsolateThread thread) {
+        if (javaBuffer.get(thread).isNonNull()) {
+            flushBufferAtSafepoint(javaBuffer.get(thread));
+            notifyEventWriter(thread);
+        }
+        if (nativeBuffer.get(thread).isNonNull()) {
+            flushBufferAtSafepoint(nativeBuffer.get(thread));
+        }
+    }
+
+
+    @Uninterruptible(reason = "Accesses a JFR buffer.")
+    private static void flushBufferAtSafepoint(JfrBuffer threadLocalBuffer) {
+        assert threadLocalBuffer.isNonNull();
+        UnsignedWord unflushedSize = JfrBufferAccess.getUnflushedSize(threadLocalBuffer);
+        if (unflushedSize.aboveThan(0)) {
+            JfrGlobalMemory globalMemory = SubstrateJVM.getGlobalMemory();
+            globalMemory.write(threadLocalBuffer, unflushedSize);
+            JfrBufferAccess.reinitialize(threadLocalBuffer);
+        }
+    }
+
+
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void writeDataLoss(JfrBuffer buffer, UnsignedWord unflushedSize) {
         assert buffer.isNonNull();

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrThreadLocal.java
@@ -242,23 +242,22 @@ public class JfrThreadLocal implements ThreadListener {
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public static void flushAndNotifyAtSafepoint(IsolateThread thread) {
         if (javaBuffer.get(thread).isNonNull()) {
-            flushBufferAtSafepoint(javaBuffer.get(thread));
+            flushAtSafepoint(javaBuffer.get(thread));
             notifyEventWriter(thread);
         }
         if (nativeBuffer.get(thread).isNonNull()) {
-            flushBufferAtSafepoint(nativeBuffer.get(thread));
+            flushAtSafepoint(nativeBuffer.get(thread));
         }
     }
 
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
-    private static void flushBufferAtSafepoint(JfrBuffer threadLocalBuffer) {
+    private static void flushAtSafepoint(JfrBuffer threadLocalBuffer) {
         assert threadLocalBuffer.isNonNull();
         UnsignedWord unflushedSize = JfrBufferAccess.getUnflushedSize(threadLocalBuffer);
         if (unflushedSize.aboveThan(0)) {
             JfrGlobalMemory globalMemory = SubstrateJVM.getGlobalMemory();
             globalMemory.write(threadLocalBuffer, unflushedSize);
-            JfrBufferAccess.reinitialize(threadLocalBuffer);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/SubstrateJVM.java
@@ -84,7 +84,7 @@ class SubstrateJVM {
 
         threadLocal = new JfrThreadLocal();
         globalMemory = new JfrGlobalMemory();
-        unlockedChunkWriter = new JfrChunkWriter();
+        unlockedChunkWriter = new JfrChunkWriter(globalMemory);
         recorderThread = new JfrRecorderThread(globalMemory, unlockedChunkWriter);
 
         initialized = false;

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/Target_jdk_jfr_internal_EventWriter.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/Target_jdk_jfr_internal_EventWriter.java
@@ -31,6 +31,10 @@ import com.oracle.svm.core.annotate.TargetClass;
 public final class Target_jdk_jfr_internal_EventWriter {
     @Alias
     @SuppressWarnings("unused")
+    boolean notified;
+
+    @Alias
+    @SuppressWarnings("unused")
     Target_jdk_jfr_internal_EventWriter(long startPos, long maxPos, long startPosAddress, long threadID, boolean valid) {
     }
 }


### PR DESCRIPTION
This persists the global buffers before changing epoch. During the epoch change, java event writers are notified and both java and native buffers are transferred to global buffers.