### PR TITLE
Free all entries when clearing table

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/UninterruptibleHashtable.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/UninterruptibleHashtable.java
@@ -70,7 +70,12 @@ public abstract class UninterruptibleHashtable<T extends UninterruptibleEntry<T>
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public void clear() {
         for (int i = 0; i < table.length; i++) {
-            free(table[i]);
+            T entry = table[i];
+            while (entry.isNonNull()) {
+                T tmp = entry;
+                entry = entry.getNext();
+                free(tmp);
+            }
             table[i] = WordFactory.nullPointer();
         }
         size = 0;


### PR DESCRIPTION
Updates clear to also loop through the UninterruptibleEntry linked list structure to free all entries