### PR TITLE
Fetch event type IDs from host VM

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrChunkWriter.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrChunkWriter.java
@@ -62,6 +62,9 @@ public final class JfrChunkWriter implements JfrUnlockedChunkWriter {
     private static final int JFR_VERSION_MINOR = 0;
     private static final int CHUNK_SIZE_OFFSET = 8;
 
+    private static final long METADATA_TYPE_ID = 0;
+    private static final long CONSTANT_POOL_TYPE_ID = 1;
+
     private final ReentrantLock lock;
     private final boolean compressedInts;
     private long notificationThreshold;
@@ -190,7 +193,7 @@ public final class JfrChunkWriter implements JfrUnlockedChunkWriter {
         // finished before the safepoint).
 
         long start = beginEvent();
-        writeCompressedLong(JfrEvents.CheckpointEvent.getId());
+        writeCompressedLong(CONSTANT_POOL_TYPE_ID);
         writeCompressedLong(JfrTicks.elapsedTicks());
         writeCompressedLong(0); // duration
         writeCompressedLong(0); // deltaToNext
@@ -228,7 +231,7 @@ public final class JfrChunkWriter implements JfrUnlockedChunkWriter {
 
     private long writeMetadataEvent(byte[] metadataDescriptor) throws IOException {
         long start = beginEvent();
-        writeCompressedLong(JfrEvents.MetadataEvent.getId());
+        writeCompressedLong(METADATA_TYPE_ID);
         writeCompressedLong(JfrTicks.elapsedTicks());
         writeCompressedLong(0); // duration
         writeCompressedLong(0); // metadata id

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrEvents.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrEvents.java
@@ -27,6 +27,9 @@ package com.oracle.svm.jfr;
 import com.oracle.svm.core.annotate.Uninterruptible;
 import jdk.jfr.EventType;
 import jdk.jfr.internal.MetadataRepository;
+import org.graalvm.compiler.core.common.NumUtil;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
 
 import java.util.List;
 
@@ -40,10 +43,12 @@ public enum JfrEvents {
 
     private final long id;
 
+    @Platforms(Platform.HOSTED_ONLY.class)
     JfrEvents(String name) {
         this.id = getEventTypeId(name);
     }
 
+    @Platforms(Platform.HOSTED_ONLY.class)
     private static long getEventTypeId(String name) {
         MetadataRepository metadata = MetadataRepository.getInstance();
         List<EventType> eventTypes = metadata.getRegisteredEventTypes();
@@ -60,6 +65,7 @@ public enum JfrEvents {
         return id;
     }
 
+    @Platforms(Platform.HOSTED_ONLY.class)
     public static int getEventCount() {
         MetadataRepository metadata = MetadataRepository.getInstance();
         List<EventType> eventTypes = metadata.getRegisteredEventTypes();
@@ -67,7 +73,6 @@ public enum JfrEvents {
         for (EventType eventType : eventTypes) {
             maxEventId = Math.max(maxEventId, eventType.getId());
         }
-        assert maxEventId + 1 < Integer.MAX_VALUE;
-        return (int) maxEventId + 1;
+        return NumUtil.safeToInt(maxEventId + 1);
     }
 }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/SubstrateJVM.java
@@ -422,7 +422,7 @@ class SubstrateJVM {
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public boolean isEnabled(JfrEvents event) {
-        return eventSettings[event.getId()].isEnabled();
+        return eventSettings[(int) event.getId()].isEnabled();
     }
 
     /** See {@link JVM#setThreshold}. */


### PR DESCRIPTION
This changes the JfrEvents enum similar to how I did it for JfrTypes.
The first two constants don't really fit there, because those are not IDs that are defined in metadata.xml. I made them constants in JfrChunkWriter instead (named like in Hotspot's ChunkParser).