### PR TITLE
Implement chunk rotation

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixRawFileOperationSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixRawFileOperationSupport.java
@@ -65,10 +65,12 @@ public class PosixRawFileOperationSupport extends AbstractRawFileOperationSuppor
         }
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     @Override
     public boolean isValid(RawFileDescriptor fd) {
         int posixFd = getPosixFileDescriptor(fd);
-        return posixFd >= 0;
+        // > 0 to ensure the default value 0 is invalid on all platforms
+        return posixFd > 0;
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixRawFileOperationSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixRawFileOperationSupport.java
@@ -25,8 +25,11 @@
 package com.oracle.svm.core.posix;
 
 import java.io.File;
+import java.nio.ByteOrder;
 
 import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.c.type.CTypeConversion;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.word.Pointer;
@@ -37,13 +40,20 @@ import org.graalvm.word.WordFactory;
 import com.oracle.svm.core.CErrorNumber;
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.annotate.Uninterruptible;
-import com.oracle.svm.core.os.RawFileOperationSupport;
+import com.oracle.svm.core.os.AbstractRawFileOperationSupport;
+import com.oracle.svm.core.os.AbstractRawFileOperationSupport.RawFileOperationSupportHolder;
 import com.oracle.svm.core.posix.headers.Errno;
 import com.oracle.svm.core.posix.headers.Fcntl;
 import com.oracle.svm.core.posix.headers.Unistd;
+import com.oracle.svm.core.util.VMError;
 
-public class PosixRawFileOperationSupport extends RawFileOperationSupport {
+public class PosixRawFileOperationSupport extends AbstractRawFileOperationSupport {
     private static final int DEFAULT_PERMISSIONS = 0666;
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public PosixRawFileOperationSupport(boolean useNativeByteOrder) {
+        super(useNativeByteOrder);
+    }
 
     @Override
     public RawFileDescriptor open(File file, FileAccessMode mode) {
@@ -142,7 +152,7 @@ public class PosixRawFileOperationSupport extends RawFileOperationSupport {
             case WRITE:
                 return Fcntl.O_WRONLY() | Fcntl.O_CREAT();
             default:
-                throw new IllegalArgumentException("Illegal file access mode '" + mode + "'.");
+                throw VMError.shouldNotReachHere();
         }
     }
 }
@@ -151,6 +161,13 @@ public class PosixRawFileOperationSupport extends RawFileOperationSupport {
 class PosixRawFileOperationFeature implements Feature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
-        ImageSingletons.add(RawFileOperationSupport.class, new PosixRawFileOperationSupport());
+        ByteOrder nativeByteOrder = ByteOrder.nativeOrder();
+        assert nativeByteOrder == ByteOrder.LITTLE_ENDIAN || nativeByteOrder == ByteOrder.BIG_ENDIAN;
+
+        PosixRawFileOperationSupport littleEndianSupport = new PosixRawFileOperationSupport(ByteOrder.LITTLE_ENDIAN == nativeByteOrder);
+        PosixRawFileOperationSupport bigEndianSupport = new PosixRawFileOperationSupport(ByteOrder.BIG_ENDIAN == nativeByteOrder);
+        PosixRawFileOperationSupport nativeByteOrderSupport = nativeByteOrder == ByteOrder.LITTLE_ENDIAN ? littleEndianSupport : bigEndianSupport;
+
+        ImageSingletons.add(RawFileOperationSupportHolder.class, new RawFileOperationSupportHolder(littleEndianSupport, bigEndianSupport, nativeByteOrderSupport));
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/AbstractRawFileOperationSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/AbstractRawFileOperationSupport.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.os;
+
+import java.io.File;
+
+import org.graalvm.compiler.api.replacements.Fold;
+import org.graalvm.compiler.word.Word;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.word.Pointer;
+import org.graalvm.word.UnsignedWord;
+import org.graalvm.word.WordFactory;
+
+import com.oracle.svm.core.annotate.Uninterruptible;
+import com.oracle.svm.core.hub.DynamicHub;
+import com.oracle.svm.core.hub.LayoutEncoding;
+import com.oracle.svm.core.snippets.KnownIntrinsics;
+
+public abstract class AbstractRawFileOperationSupport implements RawFileOperationSupport {
+    private final boolean useNativeByteOrder;
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    protected AbstractRawFileOperationSupport(boolean useNativeByteOrder) {
+        this.useNativeByteOrder = useNativeByteOrder;
+    }
+
+    @Override
+    public RawFileDescriptor open(String filename, FileAccessMode mode) {
+        return open(new File(filename), mode);
+    }
+
+    @Override
+    @Uninterruptible(reason = "Array must not move.")
+    public boolean write(RawFileDescriptor fd, byte[] data) {
+        DynamicHub hub = KnownIntrinsics.readHub(data);
+        UnsignedWord baseOffset = LayoutEncoding.getArrayBaseOffset(hub.getLayoutEncoding());
+        Pointer dataPtr = Word.objectToUntrackedPointer(data).add(baseOffset);
+        return write(fd, dataPtr, WordFactory.unsigned(data.length));
+    }
+
+    @Override
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public boolean writeBoolean(RawFileDescriptor fd, boolean data) {
+        return writeByte(fd, (byte) (data ? 1 : 0));
+    }
+
+    @Override
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public boolean writeByte(RawFileDescriptor fd, byte data) {
+        int sizeInBytes = Byte.BYTES;
+        Pointer dataPtr = StackValue.get(sizeInBytes);
+        dataPtr.writeByte(0, data);
+        return write(fd, dataPtr, WordFactory.unsigned(sizeInBytes));
+    }
+
+    @Override
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public boolean writeShort(RawFileDescriptor fd, short data) {
+        int sizeInBytes = Short.BYTES;
+        Pointer dataPtr = StackValue.get(sizeInBytes);
+        dataPtr.writeShort(0, useNativeByteOrder ? data : Short.reverseBytes(data));
+        return write(fd, dataPtr, WordFactory.unsigned(sizeInBytes));
+    }
+
+    @Override
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public boolean writeChar(RawFileDescriptor fd, char data) {
+        int sizeInBytes = Character.BYTES;
+        Pointer dataPtr = StackValue.get(sizeInBytes);
+        dataPtr.writeChar(0, useNativeByteOrder ? data : Character.reverseBytes(data));
+        return write(fd, dataPtr, WordFactory.unsigned(sizeInBytes));
+    }
+
+    @Override
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public boolean writeInt(RawFileDescriptor fd, int data) {
+        int sizeInBytes = Integer.BYTES;
+        Pointer dataPtr = StackValue.get(sizeInBytes);
+        dataPtr.writeInt(0, useNativeByteOrder ? data : Integer.reverseBytes(data));
+        return write(fd, dataPtr, WordFactory.unsigned(sizeInBytes));
+    }
+
+    @Override
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public boolean writeLong(RawFileDescriptor fd, long data) {
+        int sizeInBytes = Long.BYTES;
+        Pointer dataPtr = StackValue.get(sizeInBytes);
+        dataPtr.writeLong(0, useNativeByteOrder ? data : Long.reverseBytes(data));
+        return write(fd, dataPtr, WordFactory.unsigned(sizeInBytes));
+    }
+
+    public static class RawFileOperationSupportHolder {
+        private final RawFileOperationSupport littleEndian;
+        private final RawFileOperationSupport bigEndian;
+        private final RawFileOperationSupport nativeByteOrder;
+
+        @Platforms(Platform.HOSTED_ONLY.class)
+        public RawFileOperationSupportHolder(RawFileOperationSupport littleEndian, RawFileOperationSupport bigEndian, RawFileOperationSupport nativeByteOrder) {
+            this.littleEndian = littleEndian;
+            this.bigEndian = bigEndian;
+            this.nativeByteOrder = nativeByteOrder;
+        }
+
+        @Fold
+        public static RawFileOperationSupport getLittleEndian() {
+            RawFileOperationSupportHolder holder = ImageSingletons.lookup(RawFileOperationSupportHolder.class);
+            return holder.littleEndian;
+        }
+
+        @Fold
+        public static RawFileOperationSupport getBigEndian() {
+            RawFileOperationSupportHolder holder = ImageSingletons.lookup(RawFileOperationSupportHolder.class);
+            return holder.bigEndian;
+        }
+
+        @Fold
+        public static RawFileOperationSupport getNativeByteOrder() {
+            RawFileOperationSupportHolder holder = ImageSingletons.lookup(RawFileOperationSupportHolder.class);
+            return holder.nativeByteOrder;
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/RawFileOperationSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/RawFileOperationSupport.java
@@ -86,6 +86,7 @@ public interface RawFileOperationSupport {
      *
      * @return true if the file descriptor is valid, false otherwise.
      */
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     boolean isValid(RawFileDescriptor fd);
 
     /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/RawFileOperationSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/RawFileOperationSupport.java
@@ -26,27 +26,43 @@ package com.oracle.svm.core.os;
 
 import java.io.File;
 
-import org.graalvm.compiler.word.Word;
-import org.graalvm.nativeimage.ImageSingletons;
-import org.graalvm.nativeimage.StackValue;
+import org.graalvm.compiler.api.replacements.Fold;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.SignedWord;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.WordBase;
-import org.graalvm.word.WordFactory;
 
 import com.oracle.svm.core.annotate.Uninterruptible;
-import com.oracle.svm.core.hub.DynamicHub;
-import com.oracle.svm.core.hub.LayoutEncoding;
-import com.oracle.svm.core.snippets.KnownIntrinsics;
+import com.oracle.svm.core.os.AbstractRawFileOperationSupport.RawFileOperationSupportHolder;
 
 /**
  * Provides an OS-independent abstraction for operations on files. Most of the code is implemented
  * in a way that it can be used from uninterruptible code.
  */
-public abstract class RawFileOperationSupport {
-    public static RawFileOperationSupport singleton() {
-        return ImageSingletons.lookup(RawFileOperationSupport.class);
+public interface RawFileOperationSupport {
+    /**
+     * Returns a {@link RawFileOperationSupport} singleton that uses little endian byte ordering.
+     */
+    @Fold
+    static RawFileOperationSupport littleEndian() {
+        return RawFileOperationSupportHolder.getLittleEndian();
+    }
+
+    /**
+     * Returns a {@link RawFileOperationSupport} singleton that uses big endian byte ordering.
+     */
+    @Fold
+    static RawFileOperationSupport bigEndian() {
+        return RawFileOperationSupportHolder.getBigEndian();
+    }
+
+    /**
+     * Returns a {@link RawFileOperationSupport} singleton that uses the native byte ordering of the
+     * underlying architecture.
+     */
+    @Fold
+    static RawFileOperationSupport nativeByteOrder() {
+        return RawFileOperationSupportHolder.getNativeByteOrder();
     }
 
     /**
@@ -55,9 +71,7 @@ public abstract class RawFileOperationSupport {
      * @return If the operation is successful, it returns the file descriptor. Otherwise, it returns
      *         a value where {@link #isValid} will return false.
      */
-    public RawFileDescriptor open(String filename, FileAccessMode mode) {
-        return open(new File(filename), mode);
-    }
+    RawFileDescriptor open(String filename, FileAccessMode mode);
 
     /**
      * Opens or creates a file with the specified {@link FileAccessMode access mode}.
@@ -65,14 +79,14 @@ public abstract class RawFileOperationSupport {
      * @return If the operation is successful, it returns the file descriptor. Otherwise, it returns
      *         a value where {@link #isValid} will return false.
      */
-    public abstract RawFileDescriptor open(File file, FileAccessMode mode);
+    RawFileDescriptor open(File file, FileAccessMode mode);
 
     /**
      * Checks if a file descriptor is valid or if it represents an error value.
      *
      * @return true if the file descriptor is valid, false otherwise.
      */
-    public abstract boolean isValid(RawFileDescriptor fd);
+    boolean isValid(RawFileDescriptor fd);
 
     /**
      * Closes a file descriptor.
@@ -80,7 +94,7 @@ public abstract class RawFileOperationSupport {
      * @return true if the file descriptor was closed by the call, false otherwise.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public abstract boolean close(RawFileDescriptor fd);
+    boolean close(RawFileDescriptor fd);
 
     /**
      * Returns the size of a file.
@@ -89,7 +103,7 @@ public abstract class RawFileOperationSupport {
      *         returns a value less than 0.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public abstract SignedWord size(RawFileDescriptor fd);
+    SignedWord size(RawFileDescriptor fd);
 
     /**
      * Gets the current file position within a file.
@@ -98,7 +112,7 @@ public abstract class RawFileOperationSupport {
      *         returns a value less than 0.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public abstract SignedWord position(RawFileDescriptor fd);
+    SignedWord position(RawFileDescriptor fd);
 
     /**
      * Sets the current file position within a file.
@@ -106,7 +120,7 @@ public abstract class RawFileOperationSupport {
      * @return true if the file position was updated to the given value, false otherwise.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public abstract boolean seek(RawFileDescriptor fd, SignedWord position);
+    boolean seek(RawFileDescriptor fd, SignedWord position);
 
     /**
      * Writes data to the current file position and advances the file position.
@@ -114,7 +128,7 @@ public abstract class RawFileOperationSupport {
      * @return true if the data was written, false otherwise.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public abstract boolean write(RawFileDescriptor fd, Pointer data, UnsignedWord size);
+    boolean write(RawFileDescriptor fd, Pointer data, UnsignedWord size);
 
     /**
      * Writes data to the current file position and advances the file position.
@@ -122,12 +136,7 @@ public abstract class RawFileOperationSupport {
      * @return true if the data was written, false otherwise.
      */
     @Uninterruptible(reason = "Array must not move.")
-    public boolean write(RawFileDescriptor fd, byte[] data) {
-        DynamicHub hub = KnownIntrinsics.readHub(data);
-        UnsignedWord baseOffset = LayoutEncoding.getArrayBaseOffset(hub.getLayoutEncoding());
-        Pointer dataPtr = Word.objectToUntrackedPointer(data).add(baseOffset);
-        return write(fd, dataPtr, WordFactory.unsigned(data.length));
-    }
+    boolean write(RawFileDescriptor fd, byte[] data);
 
     /**
      * Writes data to the current file position and advances the file position.
@@ -135,9 +144,7 @@ public abstract class RawFileOperationSupport {
      * @return true if the data was written, false otherwise.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public boolean writeBoolean(RawFileDescriptor fd, boolean data) {
-        return writeByte(fd, (byte) (data ? 1 : 0));
-    }
+    boolean writeBoolean(RawFileDescriptor fd, boolean data);
 
     /**
      * Writes data to the current file position and advances the file position.
@@ -145,68 +152,43 @@ public abstract class RawFileOperationSupport {
      * @return true if the data was written, false otherwise.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public boolean writeByte(RawFileDescriptor fd, byte data) {
-        int sizeInBytes = Byte.BYTES;
-        Pointer dataPtr = StackValue.get(sizeInBytes);
-        dataPtr.writeByte(0, data);
-        return write(fd, dataPtr, WordFactory.unsigned(sizeInBytes));
-    }
+    boolean writeByte(RawFileDescriptor fd, byte data);
 
     /**
-     * Writes a short value in the target architecture's byte ordering to the current file position
-     * and advances the file position.
+     * Writes a short value in the specified byte ordering to the current file position and advances
+     * the file position.
      *
      * @return true if the data was written, false otherwise.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public boolean writeShort(RawFileDescriptor fd, short data) {
-        int sizeInBytes = Short.BYTES;
-        Pointer dataPtr = StackValue.get(sizeInBytes);
-        dataPtr.writeShort(0, data);
-        return write(fd, dataPtr, WordFactory.unsigned(sizeInBytes));
-    }
+    boolean writeShort(RawFileDescriptor fd, short data);
 
     /**
-     * Writes a char value in the target architecture's byte ordering to the current file position
-     * and advances the file position.
+     * Writes a char value in the specified byte ordering to the current file position and advances
+     * the file position.
      *
      * @return true if the data was written, false otherwise.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public boolean writeChar(RawFileDescriptor fd, char data) {
-        int sizeInBytes = Character.BYTES;
-        Pointer dataPtr = StackValue.get(sizeInBytes);
-        dataPtr.writeChar(0, data);
-        return write(fd, dataPtr, WordFactory.unsigned(sizeInBytes));
-    }
+    boolean writeChar(RawFileDescriptor fd, char data);
 
     /**
-     * Writes an integer value in the target architecture's byte ordering to the current file
-     * position and advances the file position.
+     * Writes an integer value in the specified byte ordering to the current file position and
+     * advances the file position.
      *
      * @return true if the data was written, false otherwise.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public boolean writeInt(RawFileDescriptor fd, int data) {
-        int sizeInBytes = Integer.BYTES;
-        Pointer dataPtr = StackValue.get(sizeInBytes);
-        dataPtr.writeInt(0, data);
-        return write(fd, dataPtr, WordFactory.unsigned(sizeInBytes));
-    }
+    boolean writeInt(RawFileDescriptor fd, int data);
 
     /**
-     * Writes a long value in the target architecture's byte ordering to the current file position
-     * and advances the file position.
+     * Writes a long value in the specified byte ordering to the current file position and advances
+     * the file position.
      *
      * @return true if the data was written, false otherwise.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public boolean writeLong(RawFileDescriptor fd, long data) {
-        int sizeInBytes = Long.BYTES;
-        Pointer dataPtr = StackValue.get(sizeInBytes);
-        dataPtr.writeLong(0, data);
-        return write(fd, dataPtr, WordFactory.unsigned(sizeInBytes));
-    }
+    boolean writeLong(RawFileDescriptor fd, long data);
 
     /**
      * Reads up to bufferSize bytes of data from to the current file position and advances the file
@@ -216,20 +198,20 @@ public abstract class RawFileOperationSupport {
      *         returns a negative value.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public abstract SignedWord read(RawFileDescriptor fd, Pointer buffer, UnsignedWord bufferSize);
+    SignedWord read(RawFileDescriptor fd, Pointer buffer, UnsignedWord bufferSize);
 
     /**
      * OS-specific signed value that represents a file descriptor. It is OS-specific which values
      * represent valid file descriptors and which values represent error values, see
      * {@link RawFileOperationSupport#isValid}.
      */
-    public interface RawFileDescriptor extends WordBase {
+    interface RawFileDescriptor extends WordBase {
     }
 
     /**
      * The file access modes that can be used when opening/creating a file.
      */
-    public enum FileAccessMode {
+    enum FileAccessMode {
         READ,
         READ_WRITE,
         WRITE

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrBuffer.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrBuffer.java
@@ -78,6 +78,12 @@ public interface JfrBuffer extends PointerBase {
      * @see JfrBufferAccess#release(JfrBuffer)
      */
     @RawField
+    Pointer getTop();
+
+    @RawField
+    void setTop(Pointer value);
+
+    @RawField
     int getAcquired();
 
     /**

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrFrameTypeSerializer.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrFrameTypeSerializer.java
@@ -24,8 +24,6 @@
  */
 package com.oracle.svm.jfr;
 
-import java.io.IOException;
-
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
@@ -35,7 +33,7 @@ public class JfrFrameTypeSerializer implements JfrRepository {
     }
 
     @Override
-    public int write(JfrChunkWriter writer) throws IOException {
+    public int write(JfrChunkWriter writer) {
         writer.writeCompressedLong(JfrTypes.FrameType.getId());
 
         JfrFrameType[] values = JfrFrameType.values();

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrMethodRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrMethodRepository.java
@@ -76,8 +76,7 @@ public class JfrMethodRepository implements JfrRepository {
     }
 
     @Override
-    public int write(JfrChunkWriter writer) throws IOException {
-        assert VMOperation.isInProgressAtSafepoint();
+    public int write(JfrChunkWriter writer) {
         if (count == 0) {
             return 0;
         }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrRecorderThread.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrRecorderThread.java
@@ -96,11 +96,8 @@ public class JfrRecorderThread extends Thread {
         JfrBuffers buffers = globalMemory.getBuffers();
         for (int i = 0; i < globalMemory.getBufferCount(); i++) {
             JfrBuffer buffer = buffers.addressOf(i).read();
-            if (isFullEnough(buffer) && JfrBufferAccess.acquire(buffer)) {
-                boolean shouldNotify = chunkWriter.write(buffer);
-                JfrBufferAccess.reinitialize(buffer);
-                JfrBufferAccess.release(buffer);
-
+            if (isFullEnough(buffer)) {
+                boolean shouldNotify = persistBuffer(chunkWriter, buffer);
                 if (shouldNotify) {
                     //Checkstyle: stop
                     synchronized (Target_jdk_jfr_internal_JVM.FILE_DELTA_CHANGE) {
@@ -110,6 +107,20 @@ public class JfrRecorderThread extends Thread {
                 }
             }
         }
+    }
+
+    @Uninterruptible(reason = "Epoch must not change while in this method.")
+    private boolean persistBuffer(JfrChunkWriter chunkWriter, JfrBuffer buffer) {
+        if (JfrBufferAccess.acquire(buffer)) {
+            try {
+                boolean shouldNotify = chunkWriter.write(buffer);
+                JfrBufferAccess.reinitialize(buffer);
+                return shouldNotify;
+            } finally {
+                JfrBufferAccess.release(buffer);
+            }
+        }
+        return false;
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrRepository.java
@@ -24,8 +24,6 @@
  */
 package com.oracle.svm.jfr;
 
-import java.io.IOException;
-
 import com.oracle.svm.core.annotate.Uninterruptible;
 
 /**
@@ -39,5 +37,5 @@ public interface JfrRepository {
      * Persists the data of the previous epoch. May only be called at a safepoint, after the epoch
      * changed.
      */
-    int write(JfrChunkWriter writer) throws IOException;
+    int write(JfrChunkWriter writer);
 }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrStackTraceRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrStackTraceRepository.java
@@ -102,8 +102,7 @@ public class JfrStackTraceRepository implements JfrRepository {
     }
 
     @Override
-    public int write(JfrChunkWriter writer) throws IOException {
-        assert VMOperation.isInProgressAtSafepoint();
+    public int write(JfrChunkWriter writer) {
         if (table.getSize() == 0) {
             return 0;
         }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrStringRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrStringRepository.java
@@ -24,14 +24,11 @@
  */
 package com.oracle.svm.jfr;
 
-import java.io.IOException;
-
-import com.oracle.svm.jfr.traceid.JfrTraceIdEpoch;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
 import com.oracle.svm.core.annotate.Uninterruptible;
-import com.oracle.svm.core.thread.VMOperation;
+import com.oracle.svm.jfr.traceid.JfrTraceIdEpoch;
 
 /**
  * This class is only used for Java-level JFR events. Therefore, we can use Java heap memory for the
@@ -55,9 +52,7 @@ public class JfrStringRepository implements JfrRepository {
     }
 
     @Override
-    public int write(JfrChunkWriter writer) throws IOException {
-        assert VMOperation.isInProgressAtSafepoint();
-
+    public int write(JfrChunkWriter writer) {
         return 0;
 
         // writer.writeCompressedLong(JfrTypes.String.getId());

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrSymbolRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrSymbolRepository.java
@@ -24,7 +24,6 @@
  */
 package com.oracle.svm.jfr;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.graalvm.compiler.word.Word;
@@ -111,7 +110,7 @@ public class JfrSymbolRepository implements JfrRepository {
     }
 
     @Override
-    public int write(JfrChunkWriter writer) throws IOException {
+    public int write(JfrChunkWriter writer) {
         JfrSymbolHashtable table = getTable(true);
         if (table.getSize() == 0) {
             return 0;
@@ -136,7 +135,7 @@ public class JfrSymbolRepository implements JfrRepository {
         return 1;
     }
 
-    private void writeSymbol(JfrChunkWriter writer, JfrSymbol symbol) throws IOException {
+    private void writeSymbol(JfrChunkWriter writer, JfrSymbol symbol) {
         writer.writeCompressedLong(symbol.getId());
         writer.writeByte(JfrChunkWriter.StringEncoding.UTF8_BYTE_ARRAY.byteValue);
         byte[] value = symbol.getValue().getBytes(StandardCharsets.UTF_8);

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrTypeRepository.java
@@ -24,20 +24,18 @@
  */
 package com.oracle.svm.jfr;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
 import com.oracle.svm.core.annotate.Uninterruptible;
 import com.oracle.svm.jfr.traceid.JfrTraceId;
 import com.oracle.svm.jfr.traceid.JfrTraceIdEpoch;
 import com.oracle.svm.jfr.traceid.JfrTraceIdLoadBarrier;
-import org.graalvm.nativeimage.Platform;
-import org.graalvm.nativeimage.Platforms;
-
-import com.oracle.svm.core.thread.VMOperation;
 
 public class JfrTypeRepository implements JfrRepository {
     static class PackageInfo {
@@ -140,9 +138,7 @@ public class JfrTypeRepository implements JfrRepository {
     }
 
     @Override
-    public int write(JfrChunkWriter writer) throws IOException {
-        assert VMOperation.isInProgressAtSafepoint();
-
+    public int write(JfrChunkWriter writer) {
         // Visit all used classes, and collect their packages, modules, classloaders and possibly referenced
         // classes.
         TypeInfo typeInfo = new TypeInfo();
@@ -182,7 +178,7 @@ public class JfrTypeRepository implements JfrRepository {
         }
     }
 
-    public int writeClasses(JfrChunkWriter writer, TypeInfo typeInfo) throws IOException {
+    public int writeClasses(JfrChunkWriter writer, TypeInfo typeInfo) {
         if (typeInfo.getClasses().isEmpty()) {
             return 0;
         }
@@ -195,7 +191,7 @@ public class JfrTypeRepository implements JfrRepository {
         return 1;
     }
 
-    private void writeClass(JfrChunkWriter writer, TypeInfo typeInfo, Class<?> clazz) throws IOException {
+    private void writeClass(JfrChunkWriter writer, TypeInfo typeInfo, Class<?> clazz) {
         JfrSymbolRepository symbolRepo = SubstrateJVM.getSymbolRepository();
         writer.writeCompressedLong(JfrTraceId.getTraceId(clazz));  // key
         writer.writeCompressedLong(typeInfo.getClassLoaderId(clazz.getClassLoader()));
@@ -204,7 +200,7 @@ public class JfrTypeRepository implements JfrRepository {
         writer.writeCompressedLong(clazz.getModifiers());
     }
 
-    private int writePackages(JfrChunkWriter writer, TypeInfo typeInfo) throws IOException {
+    private int writePackages(JfrChunkWriter writer, TypeInfo typeInfo) {
         Map<String, PackageInfo> packages = typeInfo.getPackages();
         if (packages.isEmpty()) {
             return 0;
@@ -218,7 +214,7 @@ public class JfrTypeRepository implements JfrRepository {
         return 1;
     }
 
-    private void writePackage(JfrChunkWriter writer, TypeInfo typeInfo, String pkgName, PackageInfo pkgInfo) throws IOException {
+    private void writePackage(JfrChunkWriter writer, TypeInfo typeInfo, String pkgName, PackageInfo pkgInfo) {
         JfrSymbolRepository symbolRepo = SubstrateJVM.getSymbolRepository();
         writer.writeCompressedLong(pkgInfo.id);  // id
         writer.writeCompressedLong(symbolRepo.getSymbolId(pkgName, true, true));
@@ -226,8 +222,7 @@ public class JfrTypeRepository implements JfrRepository {
         writer.writeBoolean(false); // TODO: 'exported' field: what's this?
     }
 
-    private int writeModules(JfrChunkWriter writer, TypeInfo typeInfo) throws IOException {
-        assert VMOperation.isInProgressAtSafepoint();
+    private int writeModules(JfrChunkWriter writer, TypeInfo typeInfo) {
         Map<Module, Long> modules = typeInfo.getModules();
         if (modules.isEmpty()) {
             return 0;
@@ -241,7 +236,7 @@ public class JfrTypeRepository implements JfrRepository {
         return 1;
     }
 
-    private void writeModule(JfrChunkWriter writer, TypeInfo typeInfo, Module module, long id) throws IOException {
+    private void writeModule(JfrChunkWriter writer, TypeInfo typeInfo, Module module, long id) {
         JfrSymbolRepository symbolRepo = SubstrateJVM.getSymbolRepository();
         writer.writeCompressedLong(id);
         writer.writeCompressedLong(symbolRepo.getSymbolId(module.getName(), true));
@@ -250,8 +245,7 @@ public class JfrTypeRepository implements JfrRepository {
         writer.writeCompressedLong(typeInfo.getClassLoaderId(module.getClassLoader()));
     }
 
-    private int writeClassLoaders(JfrChunkWriter writer, TypeInfo typeInfo) throws IOException {
-        assert VMOperation.isInProgressAtSafepoint();
+    private int writeClassLoaders(JfrChunkWriter writer, TypeInfo typeInfo) {
         Map<ClassLoader, Long> classLoaders = typeInfo.getClassLoaders();
         if (classLoaders.isEmpty()) {
             return 0;
@@ -265,7 +259,7 @@ public class JfrTypeRepository implements JfrRepository {
         return 1;
     }
 
-    private void writeClassLoader(JfrChunkWriter writer, ClassLoader cl, long id) throws IOException {
+    private void writeClassLoader(JfrChunkWriter writer, ClassLoader cl, long id) {
         JfrSymbolRepository symbolRepo = SubstrateJVM.getSymbolRepository();
         writer.writeCompressedLong(id);
         if (cl == null) {

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/SubstrateJVM.java
@@ -87,7 +87,7 @@ class SubstrateJVM {
 
         threadLocal = new JfrThreadLocal();
         globalMemory = new JfrGlobalMemory();
-        unlockedChunkWriter = new JfrChunkWriter();
+        unlockedChunkWriter = new JfrChunkWriter(globalMemory);
         recorderThread = new JfrRecorderThread(globalMemory, unlockedChunkWriter);
 
         initialized = false;

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/Target_jdk_jfr_internal_EventWriter.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/Target_jdk_jfr_internal_EventWriter.java
@@ -31,6 +31,10 @@ import com.oracle.svm.core.annotate.TargetClass;
 public final class Target_jdk_jfr_internal_EventWriter {
     @Alias
     @SuppressWarnings("unused")
+    boolean notified;
+
+    @Alias
+    @SuppressWarnings("unused")
     Target_jdk_jfr_internal_EventWriter(long startPos, long maxPos, long startPosAddress, long threadID, boolean valid) {
     }
 }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/traceid/JfrTraceIdLoadBarrier.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/traceid/JfrTraceIdLoadBarrier.java
@@ -72,7 +72,6 @@ public class JfrTraceIdLoadBarrier {
     }
 
     public static int classCount(boolean epoch) {
-        assert VMOperation.isInProgressAtSafepoint();
         return epoch ? classCount1.get() : classCount0.get();
     }
 
@@ -92,7 +91,6 @@ public class JfrTraceIdLoadBarrier {
     public interface ClassConsumer extends Consumer<Class<?>> {}
 
     public static void doClasses(ClassConsumer kc, boolean epoch) {
-        assert VMOperation.isInProgressAtSafepoint();
         long predicate = JfrTraceId.TRANSIENT_BIT;
         predicate |= epoch ? JfrTraceIdEpoch.EPOCH_1_BIT : JfrTraceIdEpoch.EPOCH_0_BIT;
         int usedClassCount = 0;


### PR DESCRIPTION
This implements the rest of the chunk rotation process.

Safepoint:
Uninterruptibly writes all buffers to disk, notifies Java thread local event writers to restart their writes and changes the epoch

Post-safepoint:
Writes checkpoint event, metadata event, patches chunk header and closes the chunk file


The patch relies on Christian's work to add support for uninterruptibly writing big endian data to disk.