### PR TITLE
Fix writing of unnamed module

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrSymbolRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrSymbolRepository.java
@@ -92,6 +92,11 @@ public class JfrSymbolRepository implements JfrRepository {
 
     @Uninterruptible(reason = "Epoch must not change while in this method.")
     public long getSymbolId(String imageHeapString, boolean previousEpoch, boolean replaceDotWithSlash) {
+
+        if (imageHeapString == null) {
+            return 0;
+        }
+
         assert Heap.getHeap().isInImageHeap(imageHeapString);
 
         JfrSymbol symbol = StackValue.get(JfrSymbol.class);

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrTypeRepository.java
@@ -164,7 +164,7 @@ public class JfrTypeRepository implements JfrRepository {
     }
 
     private void visitPackage(TypeInfo typeInfo, Package pkg, Module module) {
-        if (pkg != null && typeInfo.addPackage(pkg, module)) {
+        if (pkg != null && !"".equals(pkg.getName()) && typeInfo.addPackage(pkg, module)) {
             visitModule(typeInfo, module);
         }
     }
@@ -176,7 +176,8 @@ public class JfrTypeRepository implements JfrRepository {
     }
 
     private void visitClassLoader(TypeInfo typeInfo, ClassLoader classLoader) {
-        if (classLoader != null && typeInfo.addClassLoader(classLoader)) {
+        // Note: null class-loader is ok, we serialize it as "bootstrap" class-loader.
+        if (typeInfo.addClassLoader(classLoader) && classLoader != null) {
             visitClass(typeInfo, classLoader.getClass());
         }
     }
@@ -271,7 +272,12 @@ public class JfrTypeRepository implements JfrRepository {
     private void writeClassLoader(JfrChunkWriter writer, ClassLoader cl, long id) throws IOException {
         JfrSymbolRepository symbolRepo = SubstrateJVM.getSymbolRepository();
         writer.writeCompressedLong(id);
-        writer.writeCompressedLong(JfrTraceId.getTraceId(cl.getClass()));
-        writer.writeCompressedLong(symbolRepo.getSymbolId(cl.getName(), true));
+        if (cl == null) {
+            writer.writeCompressedLong(0);
+            writer.writeCompressedLong(symbolRepo.getSymbolId("bootstrap", true));
+        } else {
+            writer.writeCompressedLong(JfrTraceId.getTraceId(cl.getClass()));
+            writer.writeCompressedLong(symbolRepo.getSymbolId(cl.getName(), true));
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrTypeRepository.java
@@ -248,7 +248,7 @@ public class JfrTypeRepository implements JfrRepository {
         if (name == null) {
             name = "unnamed module";
         }
-        writer.writeCompressedLong(symbolRepo.getSymbolId(name,true));
+        writer.writeCompressedLong(symbolRepo.getSymbolId(name, true));
         writer.writeCompressedLong(0); // Version?
         writer.writeCompressedLong(0); // Location?
         writer.writeCompressedLong(typeInfo.getClassLoaderId(module.getClassLoader()));

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrTypeRepository.java
@@ -243,7 +243,11 @@ public class JfrTypeRepository implements JfrRepository {
     private void writeModule(JfrChunkWriter writer, TypeInfo typeInfo, Module module, long id) throws IOException {
         JfrSymbolRepository symbolRepo = SubstrateJVM.getSymbolRepository();
         writer.writeCompressedLong(id);
-        writer.writeCompressedLong(symbolRepo.getSymbolId(module.getName(), true));
+        String name = module.getName();
+        if (name == null) {
+            name = "unnamed module";
+        }
+        writer.writeCompressedLong(symbolRepo.getSymbolId(name,true));
         writer.writeCompressedLong(0); // Version?
         writer.writeCompressedLong(0); // Location?
         writer.writeCompressedLong(typeInfo.getClassLoaderId(module.getClassLoader()));

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrTypeRepository.java
@@ -244,13 +244,9 @@ public class JfrTypeRepository implements JfrRepository {
     private void writeModule(JfrChunkWriter writer, TypeInfo typeInfo, Module module, long id) throws IOException {
         JfrSymbolRepository symbolRepo = SubstrateJVM.getSymbolRepository();
         writer.writeCompressedLong(id);
-        String name = module.getName();
-        if (name == null) {
-            name = "unnamed module";
-        }
-        writer.writeCompressedLong(symbolRepo.getSymbolId(name, true));
-        writer.writeCompressedLong(0); // Version?
-        writer.writeCompressedLong(0); // Location?
+        writer.writeCompressedLong(symbolRepo.getSymbolId(module.getName(), true));
+        writer.writeCompressedLong(0); // Version? E.g. "11.0.10-internal"
+        writer.writeCompressedLong(0); // Location? E.g. "jrt:/java.base"
         writer.writeCompressedLong(typeInfo.getClassLoaderId(module.getClassLoader()));
     }
 


### PR DESCRIPTION
Unnamed modules have null name. The symbol repository expects non-null name, and thus crash/assert. This is fixed by returning 0 when symbol ID is requested for null strings. This seems consistent with JDK behaviour.
(btw, tests FTW, I'll brush up the tests PR once event writing works, and then provide a corresponding testcase).