### PR TITLE
Fix ThreadStart event metadata

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/types/metadata.xml
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/types/metadata.xml
@@ -615,6 +615,10 @@ questions.
     <Field type="string" name="osVersion" label="OS Version" />
   </Event>
 
+  <Event name="VirtualizationInformation" category="Operating System" label="Virtualization Information" period="endChunk">
+    <Field type="string" name="name" label="Name" />
+  </Event>
+
   <Event name="InitialSystemProperty" category="Java Virtual Machine" label="Initial System Property" description="System Property at JVM start" period="endChunk">
     <Field type="string" name="key" label="Key" />
     <Field type="string" name="value" label="Value" />
@@ -746,8 +750,8 @@ questions.
     <Field type="int" name="standardCompileCount" label="Standard Compilations" />
     <Field type="ulong" contentType="bytes" name="osrBytesCompiled" label="OSR Bytes Compiled" />
     <Field type="ulong" contentType="bytes" name="standardBytesCompiled" label="Standard Bytes Compiled" />
-    <Field type="ulong" contentType="bytes" name="nmetodsSize" label="Compilation Resulting Size" />
-    <Field type="ulong" contentType="bytes" name="nmetodCodeSize" label="Compilation Resulting Code Size" />
+    <Field type="ulong" contentType="bytes" name="nmethodsSize" label="Compilation Resulting Size" />
+    <Field type="ulong" contentType="bytes" name="nmethodCodeSize" label="Compilation Resulting Code Size" />
     <Field type="long" contentType="millis" name="peakTimeSpent" label="Peak Time" />
     <Field type="long" contentType="millis" name="totalTimeSpent" label="Total time" />
   </Event>

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/types/metadata.xml
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/types/metadata.xml
@@ -29,6 +29,7 @@ questions.
 <Metadata>
   <Event name="ThreadStart" category="Java Application" label="Java Thread Start" thread="true" startTime="false">
     <Field type="Thread" name="thread" label="Java Thread" />
+    <Field type="Thread" name="parentThread" label="Parent Java Thread" />
   </Event>
 
   <Event name="ThreadEnd" category="Java Application" label="Java Thread End" thread="true" startTime="false">


### PR DESCRIPTION
This field was missing causing the events to be considered corrupt for `jfr` tool in JDK 11. Interestingly the later versions in e.g. JDK 16+ are fine.

But in general, it should be made accurate to what the event structure is in the codebase.