### PR TITLE
Clear classes after iteration

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/traceid/JfrTraceId.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/traceid/JfrTraceId.java
@@ -83,6 +83,14 @@ public class JfrTraceId {
     }
 
     @Uninterruptible(reason = "Epoch must not change.")
+    public static void clearUsedThisEpoch(Class<?> clazz, boolean epoch) {
+        long bits = epoch ? JfrTraceIdEpoch.EPOCH_1_BIT : JfrTraceIdEpoch.EPOCH_0_BIT;
+        JfrTraceIdMap map = getTraceIdMap();
+        long id = map.getId(clazz);
+        map.setId(clazz, id & ~bits);
+    }
+
+    @Uninterruptible(reason = "Epoch must not change.")
     public static boolean isUsedThisEpoch(Class<?> clazz) {
         return predicate(clazz, TRANSIENT_BIT | JfrTraceIdEpoch.getInstance().thisEpochBit());
     }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/traceid/JfrTraceIdLoadBarrier.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/traceid/JfrTraceIdLoadBarrier.java
@@ -98,9 +98,11 @@ public class JfrTraceIdLoadBarrier {
             if (JfrTraceId.predicate(clazz, predicate)) {
                 kc.accept(clazz);
                 usedClassCount++;
+                JfrTraceId.clearUsedThisEpoch(clazz, epoch);
             }
         }
         assert usedClassCount == classCount(epoch);
+        clear();
     }
 
     // Using Consumer<Class<?>> directly drags in other implementations which are not


### PR DESCRIPTION
We need to clear tagged classes after writing them out, otherwise we will write them again in next+1 epoch.

Testing:
 - [x] mx native-unittest com.oracle.svm.test.jdk11.jfrtest --build-args -H:+AllowVMInspection